### PR TITLE
fixes js problem when missing stacked services

### DIFF
--- a/flash/static/scripts/utils.js
+++ b/flash/static/scripts/utils.js
@@ -81,6 +81,7 @@ var bundleService = function (serviceSelector, interval) {
   }
 
   function updateStacked() {
+    if (stacked.length === 0) return;
     var currentActive = active++ % stacked.length;
     wrapper.children().hide();
 


### PR DESCRIPTION
fixes `Uncaught TypeError: Cannot read property 'show' of undefined` when running on the browser. 
this is caused by calling `stacked[currentActive].show()` when `stacked` is an empty array
